### PR TITLE
feat: only use color output if it is a tty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ readme = "README.md"
 [dependencies]
 flexi_logger = "0.14.5"
 log = "0.4.8"
+atty = "0.2.13"


### PR DESCRIPTION
When the log is piped to a file there shouldn't be any ANSI color sequences.