### PR TITLE
docs: Improve documentation and add example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,5 @@
-# A logging library used by Filecoin
-
-This crate is used to make sure that all Filecoin related crates log in the same format.
+/*!
+Using `fil_logger`.
 
 By default the `fil_logger` doesn't log anything. You can change this by setting the `RUST_LOG`
 environment variable to another level. This will show log output on stderr. Example:
@@ -26,10 +25,8 @@ $ GOLOG_LOG_FMT=json RUST_LOG=info cargo run --example simple
 {"level":"warn","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:31","msg":"logging on warn level"}"
 {"level":"error","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:32","msg":"logging on error level"}"
 ```
+*/
 
-## Example
-
-```rust
 use fil_logger;
 use log::{debug, error, info, trace, warn};
 
@@ -42,11 +39,3 @@ fn main() {
     warn!("logging on warn level");
     error!("logging on error level");
 }
-```
-
-## License
-
-The Filecoin Project is dual-licensed under Apache 2.0 and MIT terms:
-
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,24 @@
 //! error!("error!");
 //! ```
 //!
+//! The default output looks like this (with log level debug):
+//!
+//! ```text
+//! 2019-11-11T21:04:25.685 DEBUG simple > debug information
+//! 2019-11-11T21:04:25.685 INFO simple > normal information
+//! 2019-11-11T21:04:25.685 WARN simple > a warning
+//! 2019-11-11T21:04:25.685 ERROR simple > error!
+//! ```
+//!
+//! It is also possible to log as JSON, which is more verbose and contains the filename and line
+//! number as additional information. To enable it, set the environment variable
+//! `GOLOG_LOG_FMT=json`:
+//!
+//! {"level":"debug","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:37",",sg":"debug information"}"
+//! {"level":"info","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:38","msg":"//! normal information"}"
+//! {"level":"warn","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:39","msg":"//! a warning"}"
+//! {"level":"error","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:40","msg":"error!"}"
+//!
 //! [env_logger]: https://crates.io/crates/env_logger
 mod single_file_writer;
 


### PR DESCRIPTION
Run the example via `RUST_LOG=debug cargo run --example simple`.

This is the last commit before I'll do the initial release and then start integrating it into the Filecoin Rust crates.