### PR TITLE
docs: remove the erroneous quote from JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ call:
 $ GOLOG_LOG_FMT=json RUST_LOG=info cargo run --example simple
     Finished dev [unoptimized + debuginfo] target(s) in 0.03s
      Running `target/debug/examples/simple`
-{"level":"info","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:30","msg":"logging on into level"}"
-{"level":"warn","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:31","msg":"logging on warn level"}"
-{"level":"error","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:32","msg":"logging on error level"}"
+{"level":"info","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:30","msg":"logging on into level"}
+{"level":"warn","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:31","msg":"logging on warn level"}
+{"level":"error","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:32","msg":"logging on error level"}
 ```
 
 ## Example

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,9 +21,9 @@ call:
 $ GOLOG_LOG_FMT=json RUST_LOG=info cargo run --example simple
     Finished dev [unoptimized + debuginfo] target(s) in 0.03s
      Running `target/debug/examples/simple`
-{"level":"info","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:30","msg":"logging on into level"}"
-{"level":"warn","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:31","msg":"logging on warn level"}"
-{"level":"error","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:32","msg":"logging on error level"}"
+{"level":"info","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:30","msg":"logging on into level"}
+{"level":"warn","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:31","msg":"logging on warn level"}
+{"level":"error","ts":"2019-11-11T20:59:31.168+01:00","logger":"simple","caller":"examples/simple.rs:32","msg":"logging on error level"}
 ```
 */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@
 //! number as additional information. To enable it, set the environment variable
 //! `GOLOG_LOG_FMT=json`:
 //!
-//! {"level":"debug","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:37",",sg":"debug information"}"
-//! {"level":"info","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:38","msg":"//! normal information"}"
-//! {"level":"warn","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:39","msg":"//! a warning"}"
-//! {"level":"error","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:40","msg":"error!"}"
+//! {"level":"debug","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:37",",sg":"debug information"}
+//! {"level":"info","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:38","msg":"//! normal information"}
+//! {"level":"warn","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:39","msg":"//! a warning"}
+//! {"level":"error","ts":"2019-11-11T21:06:45.401+01:00","logger":"simple","caller":"examples/simple.rs:40","msg":"error!"}
 //!
 //! [env_logger]: https://crates.io/crates/env_logger
 mod single_file_writer;


### PR DESCRIPTION
There was an erroneous trailing quote in the JSON output, which was fixed in
a previous commit, but the documentation wasn't updated.