### PR TITLE
fix: JSON escape in simple cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,13 +74,13 @@ pub fn go_log_json_format(
     };
     write!(
         writer,
-        r#"{{"level":"{}","ts":"{}","logger":"{}","caller":"{}:{}","msg":"{}"}}"#,
+        r#"{{"level":"{}","ts":"{}","logger":"{}","caller":"{}:{}","msg":{:?}}}"#,
         level,
         now.now().format("%Y-%m-%dT%H:%M:%S%.3f%z"),
         record.module_path().unwrap_or("<unnamed>"),
         record.file().unwrap_or("<unnamed>"),
         record.line().unwrap_or(0),
-        &record.args()
+        &record.args().to_string()
     )
 }
 


### PR DESCRIPTION
This is a simplified version of #11.
This PR use {:?} for json escaping, which is enough for our cases.

Close #10