### PR TITLE
fix: correct date and time formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,12 @@ pub fn go_log_json_format(
     )
 }
 
-const GO_TIME_FORMAT: &[time::format_description::FormatItem<'static>] =
-    time::macros::format_description!("%Y-%m-%dT%H:%M:%S%.3f%z");
-const DEFAULT_TIME_FORMAT: &[time::format_description::FormatItem<'static>] =
-    time::macros::format_description!("%Y-%m-%dT%H:%M:%S%.3f");
+const GO_TIME_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
+    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3][offset_hour sign:mandatory][offset_minute]"
+);
+const DEFAULT_TIME_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
+    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]"
+);
 
 /// Logs with color, contains the same information as the [pretty_env_logger].
 ///


### PR DESCRIPTION
The wasn't really a date and time formatting in the last release, this
commit fixes it and the time formats again look as expected:

```
$ RUST_LOG=info cargo run --example simple
2022-04-22T16:26:03.967 INFO simple > logging on into level
2022-04-22T16:26:03.967 WARN simple > logging on warn level
2022-04-22T16:26:03.967 ERROR simple > logging on error level
2022-04-22T16:26:03.967 INFO simple > logging string with json: {"hello": true}
```

```
$ GOLOG_LOG_FMT=json RUST_LOG=info cargo run --example simple
{"level":"info","ts":"2022-04-22T16:26:48.763+0200","logger":"simple","caller":"examples/simple.rs:39","msg":"logging on into level"}
{"level":"warn","ts":"2022-04-22T16:26:48.764+0200","logger":"simple","caller":"examples/simple.rs:40","msg":"logging on warn level"}
{"level":"error","ts":"2022-04-22T16:26:48.764+0200","logger":"simple","caller":"examples/simple.rs:41","msg":"logging on error level"}
{"level":"info","ts":"2022-04-22T16:26:48.764+0200","logger":"simple","caller":"examples/simple.rs:43","msg":"logging string with json: {\"hello\": true}"}
```