### PR TITLE
fix(time): Use chrono for offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filecoin-project/rust-fil-logger"
 readme = "README.md"
 
 [dependencies]
-flexi_logger = "0.22.3"
+flexi_logger = { version = "0.23", features = ["use_chrono_for_offset"] }
 log = "0.4.8"
 atty = "0.2.13"
 time = "0.3.9"


### PR DESCRIPTION
`chrono` has fixed its vulnerability since [v4.2.0](https://github.com/chronotope/chrono/releases/tag/v0.4.20)

Fix #17