### PR TITLE
fix: make local times work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/filecoin-project/rust-fil-logger"
 readme = "README.md"
 
 [dependencies]
-flexi_logger = "0.22.3"
+flexi_logger = "0.24.0"
 log = "0.4.8"
 atty = "0.2.13"
-time = "0.3.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub fn go_log_json_format(
         writer,
         r#"{{"level":"{}","ts":"{}","logger":"{}","caller":"{}:{}","msg":{:?}}}"#,
         level,
-        now.format(GO_TIME_FORMAT),
+        now.now().format(GO_TIME_FORMAT),
         record.module_path().unwrap_or("<unnamed>"),
         record.file().unwrap_or("<unnamed>"),
         record.line().unwrap_or(0),
@@ -84,12 +84,8 @@ pub fn go_log_json_format(
     )
 }
 
-const GO_TIME_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
-    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3][offset_hour sign:mandatory][offset_minute]"
-);
-const DEFAULT_TIME_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
-    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]"
-);
+const GO_TIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f%z";
+const DEFAULT_TIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f";
 
 /// Logs with color, contains the same information as the [pretty_env_logger].
 ///
@@ -109,7 +105,7 @@ pub fn color_logger_format(
     write!(
         writer,
         "{} {} {} > {}",
-        now.format(DEFAULT_TIME_FORMAT),
+        now.now().format(DEFAULT_TIME_FORMAT),
         style(level).paint(level.to_string()),
         record.module_path().unwrap_or("<unnamed>"),
         record.args(),


### PR DESCRIPTION
Due to https://rustsec.org/advisories/RUSTSEC-2020-0159, it wasn't possible to get the local time in multi-threaded contexts. This was fixed with the latest release v0.24 of `flexi_logger`. It is using a fixed version of `chrono`, which also means that we don't have a dependency on `time` anymore.

Fixes #17.
Closes #18.